### PR TITLE
fix: deploy stage is not necessary yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,5 @@ jobs:
     - stage: test
       name: 'Automation Tests'
       script: yarn test
-    - stage: deploy
-      name: 'Deploy Stage'
-      script: yarn build
 after_script:
   - yarn clean


### PR DESCRIPTION
# Description

Deploy stage in travis CI is deleted for the moment

## Enumerate the changes

 - Stage of deploy deleted